### PR TITLE
fix: update deprecated EOS.undent block in formula

### DIFF
--- a/sudo-touchid.rb
+++ b/sudo-touchid.rb
@@ -17,7 +17,7 @@ class SudoTouchid < Formula
     bin.install 'build/Release/sudo'
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
         sudo requires appropriate owner and mode: 
 
         /usr/bin/sudo chown root:wheel #{opt_prefix}/bin/sudo


### PR DESCRIPTION
Reference: Homebrew/brew#3738

Thanks for add formula for Homebrew. I fixed error in installation process.